### PR TITLE
Update Docker tags to use commit SHA only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,11 +103,11 @@ jobs:
           file: ./Dockerfile
           push: false
           load: true
-          tags: mcp:${{ github.event.pull_request.number }}-${{ github.sha }}
+          tags: mcp:${{ github.sha }}
 
       - name: Cleanup
         if: always()
-        run: docker image rm mcp:${{ github.event.pull_request.number }}-${{ github.sha }}
+        run: docker image rm mcp:${{ github.sha }}
 
   release:
     name: Test Release


### PR DESCRIPTION
Removed the pull request number from Docker image tags in the CI workflow for simplicity and consistency. Adjusted the cleanup step accordingly to match the new tag format.