### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,11 +103,11 @@ jobs:
           file: ./Dockerfile
           push: false
           load: true
-          tags: mcp:${{ github.event.pull_request.number }}-${{ github.sha }}
+          tags: mcp:${{ github.sha }}
 
       - name: Cleanup
         if: always()
-        run: docker image rm mcp:${{ github.event.pull_request.number }}-${{ github.sha }}
+        run: docker image rm mcp:${{ github.sha }}
 
   release:
     name: Test Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,5 @@ jobs:
         with:
           version: '~> v2'
           args: release --clean
-          workdir: backend
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows for CI and release processes. The changes simplify the tagging and cleanup steps in the CI workflow and remove an unnecessary argument in the release workflow.

Changes to CI workflow:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L106-R110): Simplified the Docker image tagging and cleanup steps by removing the pull request number from the tag.

Changes to release workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L35): Removed the `workdir` argument from the release job configuration.