### PR TITLE
Add mcp-frontend service and goreleaser Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,25 @@ services:
         loki-batch-size: "400"
         labels: "job=mcp-client"
 
+  mcp-frontend:
+    image: ghcr.io/shaharia-lab/mcp-frontend:latest
+    container_name: mcp-frontend
+    ports:
+      - "3001:80"
+    environment:
+      - VITE_MCP_BACKEND_API_ENDPOINT=http://localhost:8081
+    depends_on:
+      - mcp-client
+    networks:
+      - mcp-network
+    logging:
+      driver: loki
+      options:
+        loki-url: "http://localhost:3100/loki/api/v1/push"
+        loki-retries: "5"
+        loki-batch-size: "400"
+        labels: "job=mcp-frontend"
+
   # Prometheus - Metrics collection
   prometheus:
     image: prom/prometheus:latest

--- a/goreleaser.dockerfile
+++ b/goreleaser.dockerfile
@@ -1,0 +1,4 @@
+# This dockerfile is only used to build the backend image for the application using goreleaser.
+FROM scratch
+COPY mcp-kit /app/mcp-kit
+ENTRYPOINT []


### PR DESCRIPTION
Introduce the mcp-frontend service in docker-compose.yml with necessary configurations, including environment variables and logging. Add goreleaser.dockerfile for backend image builds, streamlining application deployment.