### PR TITLE
Add "X-MKit-Chat-UUID" header support for streaming responses

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -189,7 +189,7 @@ func setupRouter(
 		AllowedOrigins:   []string{"*"},
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
-		ExposedHeaders:   []string{"Link"},
+		ExposedHeaders:   []string{"Link", "X-MKit-Chat-UUID"},
 		AllowCredentials: true,
 		MaxAge:           300,
 	}))

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -160,8 +160,13 @@ func HandleAskStream(mcpClient *mcp.Client, logger *log.Logger, historyStorage g
 		}
 		defer reqCtx.span.End()
 
-		// Setup streaming
-		if err := setupStreamingHeaders(w); err != nil {
+		// Setup streaming headers
+		var chatUUID string
+		if reqCtx.chat != nil {
+			chatUUID = reqCtx.chat.UUID.String()
+		}
+
+		if err := setupStreamingHeaders(w, chatUUID); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -318,12 +323,17 @@ func addUserMessage(
 	return messages, nil
 }
 
-func setupStreamingHeaders(w http.ResponseWriter) error {
+func setupStreamingHeaders(w http.ResponseWriter, chatUUID string) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
+
+	if chatUUID != "" {
+		w.Header().Set("X-MKit-Chat-UUID", chatUUID)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Updated CORS configuration to expose the "X-MKit-Chat-UUID" header. Enhanced the streaming setup to include the chat UUID in response headers when available, improving traceability and debugging for client applications.
This pull request includes changes to add support for exposing and handling a new header, `X-MKit-Chat-UUID`, in the API. The most important changes include modifying the CORS configuration, updating the streaming headers setup, and ensuring the new header is included when available.

Changes to CORS configuration:

* [`cmd/api.go`](diffhunk://#diff-89cdc96cd44fc55cb509f62f12a3dc4173c8b9dfd81222cdff65f8544577920bL192-R192): Added `X-MKit-Chat-UUID` to the list of exposed headers in the CORS configuration.

Updates to streaming headers setup:

* [`internal/handler/chat.go`](diffhunk://#diff-108d955ddd5c30f9c28f9826b706d910f5308d53e2c9dec9a5d112da5e7b133bL321-R336): Updated the `setupStreamingHeaders` function to accept an additional `chatUUID` parameter and set the `X-MKit-Chat-UUID` header if the UUID is available.
* [`internal/handler/chat.go`](diffhunk://#diff-108d955ddd5c30f9c28f9826b706d910f5308d53e2c9dec9a5d112da5e7b133bL163-R169): Modified the `HandleAskStream` function to extract the chat UUID from the request context and pass it to the `setupStreamingHeaders` function.